### PR TITLE
Removing the assumed leading slash in the agent

### DIFF
--- a/agent/src/filesystem.rs
+++ b/agent/src/filesystem.rs
@@ -24,7 +24,7 @@ fn build_unix_path_string(folder_path_components: &[String]) -> String {
     if folder_path_components.is_empty() {
         "".to_string()
     } else {
-        format!("{}", folder_path_components.join("/"))
+        folder_path_components.join("/")
     }
 }
 
@@ -216,7 +216,7 @@ fn add_to_stignore_str(
     if !ignore_content.is_empty() && !ignore_content.ends_with('\n') {
         ignore_content.push('\n');
     }
-    ignore_content.push_str(&folder_path);
+    ignore_content.push_str(folder_path);
     ignore_content.push('\n');
 
     // Write back to .stignore

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,6 +2,7 @@ mod filesystem;
 mod tasks;
 
 use axum::{
+    Router,
     body::Body,
     extract::State,
     http::{Request, StatusCode},
@@ -9,12 +10,11 @@ use axum::{
     response::Response,
     routing::get,
     routing::post,
-    Router,
 };
 use tracing_subscriber::fmt;
 
 use std::env;
-use stignore_lib::{load_agent_config, AgentData};
+use stignore_lib::{AgentData, load_agent_config};
 use tokio::signal;
 
 async fn auth_middleware(

--- a/agent/src/tasks.rs
+++ b/agent/src/tasks.rs
@@ -778,7 +778,7 @@ mod tests {
 
         // Pre-create .stignore file with the movie directory
         let stignore_path = temp_dir.path().join("movies").join(".stignore");
-        std::fs::write(&stignore_path, "/Movie 1 (2023)\n").unwrap();
+        std::fs::write(&stignore_path, "Movie 1 (2023)\n").unwrap();
 
         let request_body = IgnoreRequest {
             category_id: MOVIES_ID.to_string(),
@@ -862,14 +862,14 @@ mod tests {
         let json: IgnoreResponse = response.json();
         assert!(json.success);
         assert!(json.ignored_path.is_some());
-        assert_eq!(json.ignored_path.unwrap(), "/Non-existent Movie (2025)");
+        assert_eq!(json.ignored_path.unwrap(), "Non-existent Movie (2025)");
         assert!(json.message.contains("Successfully added"));
 
         // Verify .stignore file was created with the non-existent folder
         let stignore_path = temp_dir.path().join("movies").join(".stignore");
         assert!(stignore_path.exists());
         let content = std::fs::read_to_string(&stignore_path).unwrap();
-        assert!(content.contains("/Non-existent Movie (2025)"));
+        assert!(content.contains("Non-existent Movie (2025)"));
     }
 
     // Ignore status endpoint tests
@@ -899,7 +899,7 @@ mod tests {
 
         // Pre-create .stignore file with the movie directory
         let stignore_path = temp_dir.path().join("movies").join(".stignore");
-        std::fs::write(&stignore_path, "/Movie 1 (2023)\n").unwrap();
+        std::fs::write(&stignore_path, "Movie 1 (2023)\n").unwrap();
 
         let request_body = IgnoreStatusRequest {
             category_id: MOVIES_ID.to_string(),
@@ -963,7 +963,7 @@ mod tests {
 
         // Pre-create .stignore file with a movie that doesn't exist on disk
         let stignore_path = temp_dir.path().join("movies").join(".stignore");
-        std::fs::write(&stignore_path, "/Non-existent Movie (2025)\n").unwrap();
+        std::fs::write(&stignore_path, "Non-existent Movie (2025)\n").unwrap();
 
         let request_body = IgnoreStatusRequest {
             category_id: MOVIES_ID.to_string(),
@@ -1008,7 +1008,7 @@ mod tests {
 
         // Pre-create .stignore file with one ignored item
         let stignore_path = temp_dir.path().join("movies").join(".stignore");
-        std::fs::write(&stignore_path, "/Movie 1 (2023)\n").unwrap();
+        std::fs::write(&stignore_path, "Movie 1 (2023)\n").unwrap();
 
         // Test with multiple items - some ignored, some not, some invalid
         let request_body = BulkIgnoreStatusRequest {
@@ -1076,7 +1076,7 @@ mod tests {
         let json: DeleteResponse = response.json();
         assert!(json.success);
         assert!(json.deleted_path.is_some());
-        assert_eq!(json.deleted_path.unwrap(), "/Movie 1 (2023)");
+        assert_eq!(json.deleted_path.unwrap(), "Movie 1 (2023)");
         assert!(json.message.contains("Successfully deleted"));
     }
 
@@ -1171,7 +1171,7 @@ mod tests {
         let json: DeleteResponse = response.json();
         assert!(json.success);
         assert!(json.deleted_path.is_some());
-        assert_eq!(json.deleted_path.unwrap(), "/test-file.txt");
+        assert_eq!(json.deleted_path.unwrap(), "test-file.txt");
         assert!(json.message.contains("Successfully deleted"));
 
         // Verify file was actually deleted

--- a/agent/src/tasks.rs
+++ b/agent/src/tasks.rs
@@ -1,9 +1,9 @@
 use crate::filesystem;
 use axum::{
+    Json,
     extract::{Path, State},
     http::StatusCode,
     response::{Html, IntoResponse, Response},
-    Json,
 };
 use std::path::PathBuf;
 use stignore_lib::*;
@@ -379,8 +379,8 @@ pub async fn post_delete(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::StatusCode;
     use axum::Router;
+    use axum::http::StatusCode;
     use axum_test::TestServer;
     use std::fs;
     use stignore_lib::{AgentConfig, AgentData, Category};
@@ -736,9 +736,10 @@ mod tests {
         response.assert_status(StatusCode::NOT_FOUND);
 
         let json: NotFoundResponse = response.json();
-        assert!(json
-            .message
-            .contains("Category ID 'invalid_category' not found"));
+        assert!(
+            json.message
+                .contains("Category ID 'invalid_category' not found")
+        );
     }
 
     // Ignore endpoint tests
@@ -837,9 +838,10 @@ mod tests {
 
         let json: IgnoreResponse = response.json();
         assert!(!json.success);
-        assert!(json
-            .message
-            .contains("Category ID 'nonexistent_id' not found"));
+        assert!(
+            json.message
+                .contains("Category ID 'nonexistent_id' not found")
+        );
     }
 
     #[tokio::test]
@@ -1142,9 +1144,10 @@ mod tests {
 
         let json: DeleteResponse = response.json();
         assert!(!json.success);
-        assert!(json
-            .message
-            .contains("Category ID 'nonexistent_id' not found"));
+        assert!(
+            json.message
+                .contains("Category ID 'nonexistent_id' not found")
+        );
         assert!(json.deleted_path.is_none());
     }
 

--- a/manager/src/components.rs
+++ b/manager/src/components.rs
@@ -1,8 +1,8 @@
 use axum::{
+    Json, Router,
     extract::{Query, State},
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
 };
 
 use crate::agents;

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -1,5 +1,5 @@
 use std::process::exit;
-use stignore_lib::{load_manager_config, ManagerData};
+use stignore_lib::{ManagerData, load_manager_config};
 
 pub fn load_config(filename: &str) -> ManagerData {
     match load_manager_config(filename) {

--- a/manager/src/lib.rs
+++ b/manager/src/lib.rs
@@ -8,7 +8,7 @@ use axum_template::engine::Engine;
 use tera::{Context, Result as TeraResult, Tera, Value};
 
 use axum::extract::FromRef;
-use axum::{routing::get, Router};
+use axum::{Router, routing::get};
 use tower_http::compression::CompressionLayer;
 use tower_http::services::{ServeDir, ServeFile};
 

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -1,4 +1,4 @@
-use stignore_manager::{agent_client, config, create_app, humansize_filter, AppState};
+use stignore_manager::{AppState, agent_client, config, create_app, humansize_filter};
 
 use axum_template::engine::Engine;
 use tera::{Context, Tera};

--- a/manager/tests/common/mod.rs
+++ b/manager/tests/common/mod.rs
@@ -9,7 +9,7 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use stignore_lib::*;
-use stignore_manager::{agent_client, humansize_filter, AppState};
+use stignore_manager::{AppState, agent_client, humansize_filter};
 
 pub fn create_test_config() -> ManagerData {
     ManagerData {


### PR DESCRIPTION
Fixes #3 

Looks like we were hardcoding a leading slash into various parts of the agent. This removes that as it's not valid.